### PR TITLE
Disable restore_bundled_with in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,8 @@ jobs:
       - run:
           name: Update bundler for workaround
           command: gem update bundler
-      - ruby-orbs/bundle-install
+      - ruby-orbs/bundle-install:
+          restore_bundled_with: false
       - run:
           name: Compile
           command: bundle exec rake


### PR DESCRIPTION
restore_bundled_with fails with the following error:

```
set -xe

if [ "Gemfile" == "Gemfile" ]; then
  gem install restore_bundled_with --no-document
  restore-bundled-with
fi

+ '[' Gemfile == Gemfile ']'
+ gem install restore_bundled_with --no-document
Fetching rchardet-1.8.0.gem
Fetching restore_bundled_with-1.0.0.gem
Fetching git-1.8.1.gem
Fetching thor-1.0.1.gem
Successfully installed rchardet-1.8.0
Successfully installed git-1.8.1
Successfully installed thor-1.0.1
Successfully installed restore_bundled_with-1.0.0
4 gems installed
+ restore-bundled-with
E, [2021-01-02T16:24:44.209190 #115] ERROR -- RestoreBundledWith 1.0.0: Please report from here:
E, [2021-01-02T16:24:44.209237 #115] ERROR -- RestoreBundledWith 1.0.0: https://github.com/packsaddle/ruby-restore_bundled_with/issues/new
E, [2021-01-02T16:24:44.209252 #115] ERROR -- RestoreBundledWith 1.0.0: options:
E, [2021-01-02T16:24:44.209285 #115] ERROR -- RestoreBundledWith 1.0.0: {"lockfile"=>"Gemfile.lock", "ref"=>"HEAD", "git_path"=>".", "git_options"=>{}, "new_line"=>"\n", "debug"=>false, "verbose"=>false}
Traceback (most recent call last):
	12: from /usr/local/bundle/bin/restore-bundled-with:23:in `<main>'
	11: from /usr/local/bundle/bin/restore-bundled-with:23:in `load'
	10: from /usr/local/bundle/gems/restore_bundled_with-1.0.0/exe/restore-bundled-with:5:in `<top (required)>'
	 9: from /usr/local/bundle/gems/thor-1.0.1/lib/thor/base.rb:485:in `start'
	 8: from /usr/local/bundle/gems/thor-1.0.1/lib/thor.rb:392:in `dispatch'
	 7: from /usr/local/bundle/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
	 6: from /usr/local/bundle/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
	 5: from /usr/local/bundle/gems/restore_bundled_with-1.0.0/lib/restore_bundled_with/cli.rb:36:in `restore'
	 4: from /usr/local/bundle/gems/restore_bundled_with-1.0.0/lib/restore_bundled_with/lock.rb:41:in `restore'
	 3: from /usr/local/bundle/gems/restore_bundled_with-1.0.0/lib/restore_bundled_with/repository.rb:31:in `fetch_file'
	 2: from /usr/local/bundle/gems/restore_bundled_with-1.0.0/lib/restore_bundled_with/repository.rb:21:in `git'
	 1: from /usr/local/bundle/gems/git-1.8.1/lib/git.rb:304:in `open'
/usr/local/bundle/gems/git-1.8.1/lib/git/base.rb:69:in `open': can't modify frozen Hash: {} (FrozenError)

Exited with code exit status 1

CircleCI received exit code 1
```

https://github.com/packsaddle/ruby-restore_bundled_with is archived.